### PR TITLE
Dynamic Resizing Based on VRAM

### DIFF
--- a/rerender.py
+++ b/rerender.py
@@ -56,8 +56,7 @@ def apply_color_correction(correction, original_image):
 def rerender(cfg: RerenderConfig, first_img_only: bool, key_video_path: str):
 
     # Preprocess input
-    prepare_frames(cfg.input_path, cfg.input_dir, cfg.image_resolution,
-                   cfg.crop)
+    prepare_frames(cfg.input_path, cfg.input_dir, cfg.image_resolution, cfg.crop, cfg.use_limit_device_resolution)
 
     # Load models
     if cfg.control_type == 'HED':

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,7 @@ class RerenderConfig:
                                control_strength=1,
                                seed: int = -1,
                                image_resolution: int = 512,
+                               use_limit_device_resolution: bool = False,
                                x0_strength: float = -1,
                                style_update_freq: int = 10,
                                cross_period: Tuple[float, float] = (0, 1),
@@ -75,6 +76,7 @@ class RerenderConfig:
         self.control_strength = control_strength
         self.seed = seed
         self.image_resolution = image_resolution
+        self.use_limit_device_resolution = use_limit_device_resolution
         self.x0_strength = x0_strength
         self.style_update_freq = style_update_freq
         self.cross_period = cross_period

--- a/src/config.py
+++ b/src/config.py
@@ -125,6 +125,7 @@ class RerenderConfig:
         append_if_not_none('control_strength')
         append_if_not_none('seed')
         append_if_not_none('image_resolution')
+        append_if_not_none('use_limit_device_resolution')
         append_if_not_none('x0_strength')
         append_if_not_none('style_update_freq')
         append_if_not_none('cross_period')

--- a/src/video_util.py
+++ b/src/video_util.py
@@ -111,17 +111,17 @@ def prepare_frames(input_path: str, output_dir: str, resolution: int, crop, use_
     video_to_frame(input_path, output_dir, '%04d.png', False, crop_func)
 
 
-def vram_limit_device_resolution(resolution, device="cuda"):
+def vram_limit_device_resolution_diffusion(resolution, device="cuda"):
     # get max limit target size
     gpu_vram = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)
     # table of gpu memory limit
-    gpu_table = {24: 1280, 18: 1024, 14: 768, 10: 640, 8: 576, 7: 512, 6: 448, 5: 320, 4: 192, 0: resolution}
+    gpu_table = {24: 1280, 18: 1024, 14: 768, 10: 640, 8: 576, 7: 512, 6: 448, 5: 320, 4: 192, 0: 0}
     # get user resize for gpu
     device_resolution = max(val for key, val in gpu_table.items() if key <= gpu_vram)
-    print(f"Limit VRAM is {gpu_vram} Gb.")
+    print(f"Limit VRAM is {gpu_vram} Gb and size {device_resolution}.")
     if gpu_vram < 4:
         print(f"Small VRAM to use GPU. Will be use config resolution")
     if resolution < device_resolution:
-        print(f"Video will resize before {device_resolution} for max size")
+        print(f"Video will not resize")
         return resolution
     return device_resolution

--- a/src/video_util.py
+++ b/src/video_util.py
@@ -115,10 +115,12 @@ def vram_limit_device_resolution(resolution, device="cuda"):
     # get max limit target size
     gpu_vram = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)
     # table of gpu memory limit
-    gpu_table = {24: 1280, 18: 1024, 14: 768, 10: 640, 8: 576, 7: 512, 6: 448, 5: 320, 4: 192}
+    gpu_table = {24: 1280, 18: 1024, 14: 768, 10: 640, 8: 576, 7: 512, 6: 448, 5: 320, 4: 192, 0: resolution}
     # get user resize for gpu
     device_resolution = max(val for key, val in gpu_table.items() if key <= gpu_vram)
     print(f"Limit VRAM is {gpu_vram} Gb.")
+    if gpu_vram < 4:
+        print(f"Small VRAM to use GPU. Will be use config resolution")
     if resolution < device_resolution:
         print(f"Video will resize before {device_resolution} for max size")
         return resolution

--- a/src/video_util.py
+++ b/src/video_util.py
@@ -114,11 +114,12 @@ def prepare_frames(input_path: str, output_dir: str, resolution: int, crop, use_
 def vram_limit_device_resolution(resolution, device="cuda"):
     # get max limit target size
     gpu_vram = torch.cuda.get_device_properties(device).total_memory / (1024 ** 3)
-    print(gpu_vram)
     # table of gpu memory limit
     gpu_table = {24: 1280, 18: 1024, 14: 768, 10: 640, 8: 576, 7: 512, 6: 448, 5: 320, 4: 192}
     # get user resize for gpu
     device_resolution = max(val for key, val in gpu_table.items() if key <= gpu_vram)
+    print(f"Limit VRAM is {gpu_vram} Gb.")
     if resolution < device_resolution:
+        print(f"Video will resize before {device_resolution} for max size")
         return resolution
     return device_resolution

--- a/webUI.py
+++ b/webUI.py
@@ -272,8 +272,7 @@ def process1(*args):
                                  cfg.canny_high)
     global_state.processing_state = ProcessingState.FIRST_IMG
 
-    prepare_frames(cfg.input_path, cfg.input_dir, cfg.image_resolution,
-                   cfg.crop)
+    prepare_frames(cfg.input_path, cfg.input_dir, cfg.image_resolution, cfg.crop, cfg.use_limit_device_resolution)
 
     ddim_v_sampler = global_state.ddim_v_sampler
     model = ddim_v_sampler.model


### PR DESCRIPTION
Added Dynamic Resizing Based on VRAM if option use_limit_device_resolution in cfg is True. Also keep max size by resolution and smaller side will be less than resolution. Dynamic Resizing Based on VRAM from [Issue 79](https://github.com/williamyang1991/Rerender_A_Video/issues/79)
